### PR TITLE
:pencil: Add num_workers parameter from config to dataloader initialization

### DIFF
--- a/datasets/dataloader.py
+++ b/datasets/dataloader.py
@@ -13,7 +13,7 @@ def create_dataloader(hp, args, train):
 
     if train:
         return DataLoader(dataset=dataset, batch_size=hp.train.batch_size, shuffle=True,
-            num_workers=6, pin_memory=True, drop_last=True)
+            num_workers=hp.train.num_workers, pin_memory=True, drop_last=True)
     else:
         return DataLoader(dataset=dataset, batch_size=1, shuffle=False,
             num_workers=0, pin_memory=False, drop_last=False)


### PR DESCRIPTION
Found that `train.num_workers` hyperparameter from config not used in train `dataloader` initialization.

It can cause errors while using Windows OS (As example, `OSError: [WinError 6]`), which not correctly supporting parallelization in pytorch, so it needs to `num_workers=0` used.