### PR TITLE
wrong url of VCTK pretrained model fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ pip install -r requirements.txt
 Two pretrained model are provided. Both pretrained models are trained using modified-VocGAN structure.
 * [LJSpeech-1.1](https://keithito.com/LJ-Speech-Dataset/)  (English, single-female speaker, trained for 4000 epochs) \[ [download](https://drive.google.com/file/d/1YCXTbPtVQ3aev7KsL0Cv0kZguEMKZuQp/view?usp=sharing) \]
 * [KSS dataset](https://www.kaggle.com/bryanpark/korean-single-speaker-speech-dataset)  (Korean, single-female speaker, trained for 4500 epochs) \[ [download](https://drive.google.com/file/d/1RIqMyj9vSCcGaRgAKrVB5Duvw22N6IXJ/view?usp=sharing) \]
-* [VCTK](https://datashare.ed.ac.uk/handle/10283/3443) (English, multispeaker, trained for 3180 epochs) \[[download](https://drive.google.com/file/d/1wiG8CyzNhq7dVZG3LZqCJ5bnoPTPS08a/view?usp=sharing)\]
-
+* [VCTK](https://datashare.ed.ac.uk/handle/10283/3443) (English, multispeaker, trained for 3180 epochs) \[[download](https://drive.google.com/file/d/1nfD84ot7o3u2tFR7YkSp2vQWVnNJ-md_/view?usp=sharing)\]
 
 ## Audio Samples
 Using pretrained models, we can reconstruct audio samples. Visit [here](https://drive.google.com/drive/folders/1QRS9BOQeOXV1aJHdz0ccoKzgfXJFbIKm?usp=sharing) to listen.


### PR DESCRIPTION
Dear @rishikksh20,

This is a pull request to correct url of VocGAN model pretrained on VCTK dataset.
I wrote wrong url path in README.md.

Sorry for confusion.

