### PR TITLE
Fix bug

### DIFF
--- a/utils/train.py
+++ b/utils/train.py
@@ -154,7 +154,7 @@ def train(args, pt_dir, chkpt_path, trainloader, valloader, writer, logger, hp, 
                 loss_g = loss_g.item()
                 avg_g_loss.append(loss_g)
                 avg_d_loss.append(loss_d_avg)
-                avg_adv_loss.append(adv_loss)
+                avg_adv_loss.append(adv_loss.item())
                 if any([loss_g > 1e8, math.isnan(loss_g), loss_d_avg > 1e8, math.isnan(loss_d_avg)]):
                     logger.error("loss_g %.01f loss_d_avg %.01f at step %d!" % (loss_g, loss_d_avg, step))
                     raise Exception("Loss exploded")


### PR DESCRIPTION
Hi, @rishikksh20 .


This is a pull request to avoid unnecessary memory accumulation.

I have observed a severe memory accumulation while using your VocGAN source.
I tracked the line of "utils/train.py", and found the reason of the problem.

I added ".item()" to the back of adv_loss variable, and the problem was gone.

Check this PR.


Thank you.
